### PR TITLE
Create iPad-style training microsite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,661 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>四川省矿产资源资产价格体系建设专题技术培训</title>
+    <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+    <main class="scroll-wrapper">
+        <section class="page theme-blue" id="p1">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P1 · 封面</span>
+                    <h1 class="headline">培训主题</h1>
+                    <p class="subtitle">四川省矿产资源资产价格体系建设专题技术培训</p>
+                    <div class="meta">
+                        <span>主讲人：李明轩</span>
+                        <span>2024年6月 · 成都市</span>
+                        <span class="badge">四川省自然资源厅</span>
+                    </div>
+                    <div class="logos">
+                        <div class="logo-mark">单位 Logo</div>
+                        <div class="logo-mark secondary">合作机构</div>
+                    </div>
+                    <p class="intro">立足四川地质禀赋与矿产结构，构建可复制、可推广的资产价格体系。</p>
+                </div>
+                <div class="visual hero-map" aria-hidden="true">
+                    <svg viewBox="0 0 320 320" role="img" aria-label="四川矿产与数据图形">
+                        <defs>
+                            <linearGradient id="mapGradient" x1="0" x2="1" y1="0" y2="1">
+                                <stop offset="0%" stop-color="rgba(0,122,255,0.15)" />
+                                <stop offset="100%" stop-color="rgba(72,197,255,0.4)" />
+                            </linearGradient>
+                        </defs>
+                        <rect x="0" y="0" width="320" height="320" rx="36" fill="url(#mapGradient)" />
+                        <path d="M88 68c26 18 38 9 66 10 16 1 36 24 55 23 18-1 35-17 42-3 6 13-5 27-12 39-8 15-11 36-4 53 5 14 20 24 17 38-4 16-24 19-39 23-21 6-41 24-62 22-23-3-35-27-55-36-16-6-36-3-48-16-12-14-9-35-3-51 6-17 5-35 7-53 2-17 7-36 26-49z" fill="#007aff" opacity="0.65" />
+                        <circle cx="110" cy="110" r="12" class="pulse" />
+                        <circle cx="214" cy="140" r="8" class="pulse delayed" />
+                        <polyline points="80,250 130,210 200,230 250,190" fill="none" stroke="rgba(255,255,255,0.6)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                    <div class="data-chip">四川矿产 <span>76%</span></div>
+                    <div class="data-chip secondary">战略矿种 <span>石墨·稀土</span></div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-blue" id="p2">
+            <div class="page-inner">
+                <span class="eyebrow">P2 · 课程导航</span>
+                <h2 class="headline">课程地图</h2>
+                <p class="subtitle">从方法讲解到案例实操，从成果应用到质量控制，全流程覆盖。</p>
+                <div class="course-ring">
+                    <div class="ring-core">启航</div>
+                    <div class="ring-item" style="--i:0">启航篇</div>
+                    <div class="ring-item" style="--i:1">核心技术（上）</div>
+                    <div class="ring-item" style="--i:2">核心技术（下）</div>
+                    <div class="ring-item" style="--i:3">成果保障</div>
+                    <div class="ring-item" style="--i:4">共鸣篇</div>
+                </div>
+                <div class="notes">
+                    <p class="micro-copy">滑动切换页面 · iPad Pro 横屏一屏一页</p>
+                    <p class="micro-copy">提示：点击环形节点可快速跳转对应篇章</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-blue" id="p3">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P3 · 启航篇</span>
+                    <h2 class="headline">欢迎与导入</h2>
+                    <p class="subtitle">培训定位：立足省情、解决实际难题</p>
+                    <ul class="bullet-list">
+                        <li>聚焦矿产资源资产价格体系的建设痛点与断点。</li>
+                        <li>统一省、市、县三级测算标准，打通数据采集链路。</li>
+                        <li>以案例驱动，配套省级实操模板，快速落地。</li>
+                    </ul>
+                    <div class="callout">
+                        <strong>思考？</strong> 如何在本单位建立跨部门协同机制 → <span class="cta">留言互动</span>
+                    </div>
+                </div>
+                <div class="visual video-frame" role="img" aria-label="讲师视频开场截图">
+                    <div class="video-overlay">
+                        <span>开场白节选</span>
+                        <p>“欢迎来到四川省矿产资源资产价格体系建设专题培训，我们将以实操为核心，帮助各位在短时间内掌握关键方法。”</p>
+                    </div>
+                    <button class="play-btn" aria-label="播放视频"></button>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-blue" id="p4">
+            <div class="page-inner">
+                <span class="eyebrow">P4 · 培训目标</span>
+                <h2 class="headline">三类培训目标</h2>
+                <div class="card-grid three">
+                    <article class="card">
+                        <div class="icon halo">认知</div>
+                        <h3>理解体系</h3>
+                        <p>厘清国家—省级—市县三级价格体系的职责分工，掌握关键术语。</p>
+                    </article>
+                    <article class="card">
+                        <div class="icon halo">技能</div>
+                        <h3>掌握净现值法</h3>
+                        <p>五步实操流程拆解，结合石墨案例进行参数调试与验证。</p>
+                    </article>
+                    <article class="card">
+                        <div class="icon halo">应用</div>
+                        <h3>独立完成案例</h3>
+                        <p>完成一套矿种价格测算报告，输出符合验收规范的成果包。</p>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-blue" id="p5">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P5 · 方向共识</span>
+                    <h2 class="headline">必须统一的“三个共识”</h2>
+                    <div class="consensus">
+                        <div class="consensus-item">
+                            <span class="label">时间基准</span>
+                            <strong>2023年12月31日</strong>
+                            <p>所有测算数据均以此为基准日进行回溯与折算，保证横向可比。</p>
+                        </div>
+                        <div class="consensus-item">
+                            <span class="label">核心产出</span>
+                            <strong>核算价格 = 单价</strong>
+                            <p>输出结果需聚焦单价信号，配套不确定性区间说明。</p>
+                        </div>
+                        <div class="consensus-item">
+                            <span class="label">省级职责</span>
+                            <strong>国家数据支撑 + 省级价格测算</strong>
+                            <p>省级统筹参数、模板与质控，市县负责补充实测数据。</p>
+                        </div>
+                    </div>
+                </div>
+                <aside class="next-section">
+                    <h4>下一节预告</h4>
+                    <p>核心技术篇（上）：净现值法五步实操，逐参数拆解。</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p6">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P6 · 数据来源</span>
+                    <h2 class="headline">表A.9 &amp; A.10 概览</h2>
+                    <p class="subtitle">掌握基础数据结构是成功测算的第一步。</p>
+                    <ul class="bullet-list">
+                        <li>表A.9：矿山生产运营数据，聚焦产量、销售、成本。</li>
+                        <li>表A.10：资源储量与综合利用信息，链接自然资源台账。</li>
+                        <li>缺失数据常见处理：同类矿山映射、历史同期回归、专家校核。</li>
+                    </ul>
+                </div>
+                <div class="visual data-panels">
+                    <div class="panel">
+                        <header>表A.9 核心字段</header>
+                        <ul>
+                            <li>产量（吨）</li>
+                            <li>销售收入（万元）</li>
+                            <li>单位总成本（元/吨）</li>
+                            <li>综合回收率（%）</li>
+                        </ul>
+                    </div>
+                    <div class="panel accent">
+                        <header>表A.10 核心字段</header>
+                        <ul>
+                            <li>保有储量</li>
+                            <li>设计服务年限</li>
+                            <li>伴生矿种价值</li>
+                            <li>生态修复投入</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p7">
+            <div class="page-inner">
+                <span class="eyebrow">P7 · 流程动画</span>
+                <h2 class="headline">净现值法五步法</h2>
+                <div class="flow-strip">
+                    <div class="flow-item">划分集中区</div>
+                    <div class="flow-item">选择典型区</div>
+                    <div class="flow-item">标准矿山价值</div>
+                    <div class="flow-item">核算价格</div>
+                    <div class="flow-item">平均得出最终价格</div>
+                </div>
+                <p class="caption">提示：逐步展开动画呈现关键操作要点，视频版可点击节点查看演示。</p>
+                <div class="callout">
+                    <strong>思考？</strong> 本地区典型矿山如何选取 → <span class="cta">留言互动</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p8">
+            <div class="page-inner">
+                <span class="eyebrow">P8 · 参数总览</span>
+                <h2 class="headline">三大核心参数</h2>
+                <div class="triangle-grid" aria-label="资源租金、投资回报率、折现率 三角结构">
+                    <div class="triangle-item top">
+                        <span>资源租金</span>
+                        <p>反映矿产资源稀缺价值，来源于营业收入与总成本差额。</p>
+                    </div>
+                    <div class="triangle-item left">
+                        <span>投资回报率</span>
+                        <p>体现资本收益预期，结合地区风险进行调整。</p>
+                    </div>
+                    <div class="triangle-item right">
+                        <span>折现率</span>
+                        <p>以国债利率为基准，加入风险与通胀修正。</p>
+                    </div>
+                    <div class="triangle-core">价值评估平衡点</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p9">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P9 · 资源租金</span>
+                    <h2 class="headline">资源租金计算框架</h2>
+                    <p class="subtitle">资源租金 = 营业收入 − 总成本</p>
+                    <ul class="bullet-list">
+                        <li>营业收入：产量 × 含税售价，注意扣除非经营性收入。</li>
+                        <li>总成本：直接成本 + 制造费用 + 管理费用 + 销售费用。</li>
+                        <li>调整项：生态修复投入、资源税费、折旧与摊销。</li>
+                    </ul>
+                </div>
+                <div class="visual sheet">
+                    <header>财务表格高亮</header>
+                    <table>
+                        <thead>
+                            <tr><th>项目</th><th>金额（万元）</th><th>说明</th></tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>营业收入</td><td class="highlight">12,560</td><td>剔除一次性政府补助</td></tr>
+                            <tr><td>总成本</td><td>9,840</td><td>含人工、折旧、能源</td></tr>
+                            <tr><td>资源租金</td><td class="highlight">2,720</td><td>用于价格测算</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p10">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P10 · 回报率</span>
+                    <h2 class="headline">投资回报率与风险报酬率</h2>
+                    <p class="subtitle">依据表A.12数据结合四川矿业特征。</p>
+                    <ul class="bullet-list">
+                        <li>基准回报率：参考国家发布的行业平均水平。</li>
+                        <li>风险加点：冻土期、山地运输、生态约束等因素。</li>
+                        <li>政策调节：鼓励类矿种可适当下调风险系数。</li>
+                    </ul>
+                </div>
+                <div class="visual data-panels">
+                    <div class="panel">
+                        <header>表A.12 摘要</header>
+                        <ul>
+                            <li>行业平均收益率：9.5%</li>
+                            <li>资本结构权重：自有资本 60%</li>
+                            <li>风险报酬区间：2% - 5%</li>
+                        </ul>
+                    </div>
+                    <div class="panel accent">
+                        <header>四川风险画像</header>
+                        <ul>
+                            <li>高海拔 + 雪线 → 建设周期延长</li>
+                            <li>交通半径长 → 物流成本上浮 12%</li>
+                            <li>生态红线严格 → 环保投入翻倍</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p11">
+            <div class="page-inner">
+                <span class="eyebrow">P11 · 折现率</span>
+                <h2 class="headline">折现率选取基准</h2>
+                <div class="chart">
+                    <div class="chart-grid">
+                        <div class="chart-line" style="--offset:14%;">2019</div>
+                        <div class="chart-line" style="--offset:18%;">2020</div>
+                        <div class="chart-line" style="--offset:21%;">2021</div>
+                        <div class="chart-line" style="--offset:19%;">2022</div>
+                        <div class="chart-line" style="--offset:17%;">2023</div>
+                    </div>
+                    <div class="chart-legend">
+                        <span class="dot"></span> 前五年十年期国债利率（加权）
+                    </div>
+                </div>
+                <p class="caption">建议折现率 = 国债基准 × (1 + 区域风险因子)。当风险因子 0.8% 时，折现率约为 4.3%。</p>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p12">
+            <div class="page-inner split">
+                <div class="visual excel-mock" role="img" aria-label="石墨案例数据表">
+                    <header>石墨案例 · 输入数据</header>
+                    <ul>
+                        <li>年产量：3.2 万吨</li>
+                        <li>含税售价：5,600 元/吨</li>
+                        <li>单位总成本：3,250 元/吨</li>
+                        <li>伴生收益：180 元/吨</li>
+                    </ul>
+                </div>
+                <div class="copy">
+                    <span class="eyebrow">P12 · 案例推演</span>
+                    <h2 class="headline">石墨案例：输入 → 计算 → 结果</h2>
+                    <ol class="stepper">
+                        <li><strong>输入：</strong>录入表A.9、A.10字段，校验历史数据一致性。</li>
+                        <li><strong>计算：</strong>依照五步法完成资源租金、折现率匹配与现金流折现。</li>
+                        <li><strong>结果：</strong>得出省级指导价 4,980 元/吨，附带敏感性分析。</li>
+                    </ol>
+                    <div class="callout">
+                        <strong>提示</strong> 在PS模板中预留数据更新图层，可快速替换最新年度信息。
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p13">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P13 · 小组演练</span>
+                    <h2 class="headline">课后作业提示</h2>
+                    <p class="subtitle">任务：根据给定石墨数据，完成净现值法的两个关键步骤。</p>
+                    <ul class="bullet-list">
+                        <li>步骤一：核对输入表格，补齐缺失成本与伴生收益。</li>
+                        <li>步骤二：计算折现率并完成现金流折现。</li>
+                        <li>提交方式：上传 Excel 结果 + 关键参数说明。</li>
+                    </ul>
+                    <div class="callout">
+                        <strong>思考？</strong> 哪些参数对结果最敏感 → <span class="cta">留言互动</span>
+                    </div>
+                </div>
+                <aside class="next-section">
+                    <h4>下一节预告</h4>
+                    <p>核心技术篇（下）：地区调整系数法与成果应用路径。</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p14">
+            <div class="page-inner">
+                <span class="eyebrow">P14 · 地区调整</span>
+                <h2 class="headline">地区调整系数法流程</h2>
+                <div class="flow-stack">
+                    <div class="flow-card">国家价格基准</div>
+                    <div class="flow-card">地区调整因子匹配</div>
+                    <div class="flow-card">本地化价格输出</div>
+                </div>
+                <p class="caption">动画展示：逐层激活因子，实时预览价格变化。</p>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p15">
+            <div class="page-inner">
+                <span class="eyebrow">P15 · 通用因子</span>
+                <h2 class="headline">通用调整因子（表A.11）</h2>
+                <table class="factor-table">
+                    <thead>
+                        <tr><th>因子</th><th>说明</th><th>调整方向</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr><td>交通条件</td><td>距离干线公路、铁路枢纽的便利度</td><td>-6% ~ +4%</td></tr>
+                        <tr><td>能源保障</td><td>供电、供水、燃料稳定性</td><td>-3% ~ +3%</td></tr>
+                        <tr><td>人力资源</td><td>技能人员可获得性与成本</td><td>-2% ~ +2%</td></tr>
+                        <tr class="highlight"><td>生态管控（四川）</td><td>生态红线、林区审批周期</td><td>-5% ~ 0%</td></tr>
+                        <tr class="highlight"><td>地质复杂度（四川）</td><td>高纬度、断裂密集区域</td><td>0% ~ +6%</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p16">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P16 · 四川特色因子</span>
+                    <h2 class="headline">高纬度 · 冻土期长 · 林区路网</h2>
+                    <p>将地理特征转化为参数化调整，提升模型贴合度。</p>
+                    <ul class="bullet-list">
+                        <li>高纬度与高海拔叠加，采暖与施工保温成本高。</li>
+                        <li>冻土期长导致年有效施工期缩短，折现率需加点。</li>
+                        <li>林区路网密度低，需核算专用道路投资与维护。</li>
+                    </ul>
+                </div>
+                <div class="visual map-panel">
+                    <header>四川特色地图</header>
+                    <div class="map-markers">
+                        <div class="marker">阿坝 · 石墨</div>
+                        <div class="marker">甘孜 · 铁矿</div>
+                        <div class="marker">攀枝花 · 钒钛磁铁矿</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p17">
+            <div class="page-inner">
+                <span class="eyebrow">P17 · 案例</span>
+                <h2 class="headline">铁矿价格调整流程</h2>
+                <div class="flow-strip detailed">
+                    <div class="flow-item">国家下发基准价</div>
+                    <div class="flow-item">匹配调整因子</div>
+                    <div class="flow-item">计算地区综合系数</div>
+                    <div class="flow-item">形成四川省指导价</div>
+                    <div class="flow-item">分解至地市执行价</div>
+                </div>
+                <p class="caption">每一步自动关联数据库记录，保留调整痕迹。</p>
+                <div class="callout">
+                    <strong>思考？</strong> 如何记录调整过程 → <span class="cta">留言互动</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p18">
+            <div class="page-inner">
+                <span class="eyebrow">P18 · 成果应用</span>
+                <h2 class="headline">成果应用总览</h2>
+                <div class="ring-flow">
+                    <div class="ring-node">挂接实物量</div>
+                    <div class="ring-node">经济价值核算</div>
+                    <div class="ring-node">资产负债表</div>
+                    <div class="ring-node">出让收益评估</div>
+                    <div class="ring-node">价格监测预警</div>
+                </div>
+                <p class="caption">成果系统与财政、国资、生态部门共享，实现数据协同。</p>
+            </div>
+        </section>
+
+        <section class="page theme-green" id="p19">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P19 · 四川实践</span>
+                    <h2 class="headline">四川实践价值</h2>
+                    <div class="card-grid three">
+                        <article class="card">
+                            <h3>石墨</h3>
+                            <p>支撑新材料产业链，提供动态价格监测。</p>
+                        </article>
+                        <article class="card">
+                            <h3>煤炭</h3>
+                            <p>保障能源安全，完善煤炭资源收益分配。</p>
+                        </article>
+                        <article class="card">
+                            <h3>铁矿</h3>
+                            <p>匹配重大项目建设，形成区域价格基准。</p>
+                        </article>
+                    </div>
+                </div>
+                <aside class="next-section">
+                    <h4>下一节预告</h4>
+                    <p>保障篇：成果验收与质量控制体系，确保成果可交付。</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="page theme-orange" id="p20">
+            <div class="page-inner">
+                <span class="eyebrow">P20 · 保障篇</span>
+                <h2 class="headline">四级联防质量体系</h2>
+                <div class="ladder">
+                    <div class="ladder-step">县级自检</div>
+                    <div class="ladder-step">地市复核</div>
+                    <div class="ladder-step">省级质控</div>
+                    <div class="ladder-step">国家级抽查</div>
+                </div>
+                <p class="caption">采用统一质检清单，逐级反馈与修正。</p>
+            </div>
+        </section>
+
+        <section class="page theme-orange" id="p21">
+            <div class="page-inner">
+                <span class="eyebrow">P21 · 三看原则</span>
+                <h2 class="headline">看方法 · 看参数 · 看过程</h2>
+                <div class="magnifier-grid">
+                    <div class="magnifier">方法</div>
+                    <div class="magnifier">参数</div>
+                    <div class="magnifier">过程</div>
+                </div>
+                <p class="caption">三项检查贯穿测算全流程，确保模型可追溯。</p>
+            </div>
+        </section>
+
+        <section class="page theme-orange" id="p22">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P22 · 结果判定</span>
+                    <h2 class="headline">结果判定与整改</h2>
+                    <p>通过标准化对比表格快速识别问题并给出整改建议。</p>
+                    <ul class="bullet-list">
+                        <li>合格：参数齐全、过程透明、结果可复算。</li>
+                        <li>预警：关键参数缺失或数据异常，需补充说明。</li>
+                        <li>不合格：方法偏离或结果不一致，启动复核流程。</li>
+                    </ul>
+                </div>
+                <div class="visual compare">
+                    <div class="compare-card good">
+                        <h3>合格</h3>
+                        <p>指标齐全 · 误差≤3%</p>
+                    </div>
+                    <div class="compare-card bad">
+                        <h3>不合格</h3>
+                        <p>缺失参数 · 误差&gt;5%</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-orange" id="p23">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P23 · 汇交规范</span>
+                    <h2 class="headline">成果汇交规范</h2>
+                    <ul class="bullet-list">
+                        <li>成果内容：价格信号数据表、参数说明书、敏感性分析。</li>
+                        <li>文件组织：省-市-县三级目录结构，统一命名。</li>
+                        <li>交付格式：Excel+PDF+PS模板，统一封面规范。</li>
+                    </ul>
+                </div>
+                <div class="visual folder-structure">
+                    <div class="folder">01_价格结果</div>
+                    <div class="folder">02_参数支撑</div>
+                    <div class="folder">03_过程记录</div>
+                    <div class="folder">04_图像与附件</div>
+                </div>
+                <aside class="next-section">
+                    <h4>下一节预告</h4>
+                    <p>共鸣篇：总结重点，开启互动答疑。</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="page theme-purple" id="p24">
+            <div class="page-inner">
+                <span class="eyebrow">P24 · 共鸣篇</span>
+                <h2 class="headline">核心要点一句话回顾</h2>
+                <div class="recap">
+                    <div class="recap-item">优势矿种 → 净现值法</div>
+                    <div class="recap-item">非优势矿种 → 调整系数法</div>
+                    <div class="recap-item">成果验收 → 三看原则</div>
+                </div>
+                <p class="caption">以图层化设计在PS模板中快速替换文案，实现每期培训复用。</p>
+            </div>
+        </section>
+
+        <section class="page theme-purple" id="p25">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P25 · 互动</span>
+                    <h2 class="headline">学员互动与答疑</h2>
+                    <ul class="bullet-list">
+                        <li>提问渠道：在线留言、课后问卷、微信群实时答疑。</li>
+                        <li>互动方式：选择题、自测题、FAQ 专区。</li>
+                        <li>反馈机制：问题收集后 48 小时内统一回复。</li>
+                    </ul>
+                    <div class="callout">
+                        <strong>思考？</strong> 你最期待的案例是什么 → <span class="cta">留言互动</span>
+                    </div>
+                </div>
+                <div class="visual chat-panel">
+                    <div class="bubble">讲师：本周五开启在线答疑。</div>
+                    <div class="bubble">学员A：可否分享风险系数计算模板？</div>
+                    <div class="bubble">讲师：将于答疑会统一发布。</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-purple" id="p26">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P26 · 结束语</span>
+                    <h2 class="headline">展望与下一步</h2>
+                    <p class="subtitle">感谢投入，共创四川矿产价格体系新高度。</p>
+                    <ul class="bullet-list">
+                        <li>将本次方法嵌入单位年度工作计划。</li>
+                        <li>建立动态更新机制，定期复盘参数。</li>
+                        <li>推动跨部门协同，形成闭环管理。</li>
+                    </ul>
+                </div>
+                <aside class="next-section">
+                    <h4>下一节预告</h4>
+                    <p>附录：常用表格汇编与学习资源。</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="page theme-gray" id="p27">
+            <div class="page-inner split">
+                <div class="copy">
+                    <span class="eyebrow">P27 · 附录</span>
+                    <h2 class="headline">常用表格汇编</h2>
+                    <p>快速索引 A.9、A.10、A.11、A.12 关键字段。</p>
+                </div>
+                <div class="visual data-panels">
+                    <div class="panel">
+                        <header>A.9</header>
+                        <ul>
+                            <li>生产规模</li>
+                            <li>销售收入</li>
+                            <li>成本结构</li>
+                        </ul>
+                    </div>
+                    <div class="panel">
+                        <header>A.10</header>
+                        <ul>
+                            <li>储量级别</li>
+                            <li>伴生矿信息</li>
+                            <li>恢复系数</li>
+                        </ul>
+                    </div>
+                    <div class="panel">
+                        <header>A.11</header>
+                        <ul>
+                            <li>地区调整因子</li>
+                            <li>取值范围</li>
+                        </ul>
+                    </div>
+                    <div class="panel">
+                        <header>A.12</header>
+                        <ul>
+                            <li>回报率基准</li>
+                            <li>风险报酬率</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="page theme-gray" id="p28">
+            <div class="page-inner">
+                <span class="eyebrow">P28 · 资源</span>
+                <h2 class="headline">学习资源与参考文献</h2>
+                <div class="resource-list">
+                    <article class="resource">
+                        <h3>政策类</h3>
+                        <p>《四川省矿产资源总体规划》《自然资源资产负债表编制指南》</p>
+                    </article>
+                    <article class="resource">
+                        <h3>方法类</h3>
+                        <p>《矿产资源资产评估技术规范》《净现值法应用案例集》</p>
+                    </article>
+                    <article class="resource">
+                        <h3>工具类</h3>
+                        <p>Excel 动态模板、PS 视觉模板、参数校核脚本。</p>
+                    </article>
+                </div>
+                <p class="caption">感谢关注，更多资料请访问培训资源库。</p>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,1189 @@
+:root {
+  --font-sans: "SF Pro Display", "SF Pro Text", "Helvetica Neue", "Segoe UI", sans-serif;
+  --font-mono: "SFMono-Regular", "Menlo", monospace;
+  --color-ink: #0b0f1c;
+  --color-muted: #3c4558;
+  --color-soft: #f5f7fb;
+  --color-line: rgba(12, 18, 40, 0.08);
+  --radius-large: 40px;
+  --radius-medium: 28px;
+  --radius-small: 18px;
+  --shadow-soft: 0 24px 60px rgba(15, 23, 42, 0.18);
+  --shadow-card: 0 18px 48px rgba(9, 15, 30, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  color: var(--color-ink);
+  background: var(--color-soft);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.55;
+}
+
+body::-webkit-scrollbar {
+  width: 10px;
+}
+
+body::-webkit-scrollbar-thumb {
+  background: rgba(15, 23, 42, 0.16);
+  border-radius: 999px;
+}
+
+.scroll-wrapper {
+  height: 100vh;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+}
+
+.page {
+  min-height: 100vh;
+  scroll-snap-align: start;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 7vh 6vw 6vh;
+  position: relative;
+  isolation: isolate;
+}
+
+.page::before {
+  content: "";
+  position: absolute;
+  inset: 5% 4%;
+  border-radius: var(--radius-large);
+  background: rgba(255, 255, 255, 0.58);
+  box-shadow: var(--shadow-soft);
+  filter: saturate(1.1);
+  z-index: -2;
+}
+
+.page::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -3;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.25), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(0, 0, 0, 0.1), transparent 60%);
+}
+
+.theme-blue {
+  --accent: #0a84ff;
+  --accent-soft: rgba(10, 132, 255, 0.12);
+  --accent-gradient: linear-gradient(135deg, rgba(10, 132, 255, 0.12), rgba(0, 122, 255, 0.02));
+}
+
+.theme-green {
+  --accent: #30d158;
+  --accent-soft: rgba(48, 209, 88, 0.12);
+  --accent-gradient: linear-gradient(135deg, rgba(48, 209, 88, 0.12), rgba(48, 209, 88, 0.02));
+}
+
+.theme-purple {
+  --accent: #bf5af2;
+  --accent-soft: rgba(191, 90, 242, 0.12);
+  --accent-gradient: linear-gradient(135deg, rgba(191, 90, 242, 0.14), rgba(76, 201, 240, 0.04));
+}
+
+.theme-orange {
+  --accent: #ff9f0a;
+  --accent-soft: rgba(255, 159, 10, 0.14);
+  --accent-gradient: linear-gradient(135deg, rgba(255, 159, 10, 0.14), rgba(255, 204, 0, 0.04));
+}
+
+.theme-gray {
+  --accent: #5f5f62;
+  --accent-soft: rgba(99, 102, 107, 0.16);
+  --accent-gradient: linear-gradient(135deg, rgba(116, 116, 128, 0.16), rgba(242, 242, 247, 0.3));
+}
+
+.page-inner {
+  width: min(1180px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: calc(var(--radius-large) - 8px);
+  padding: clamp(2.8rem, 4vw, 3.6rem);
+  backdrop-filter: blur(28px) saturate(1.25);
+  box-shadow: var(--shadow-card);
+  position: relative;
+}
+
+.page-inner.split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(2rem, 4vw, 3.5rem);
+  align-items: center;
+}
+
+.copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.visual {
+  position: relative;
+  display: grid;
+  place-items: center;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(11, 15, 28, 0.56);
+}
+
+.headline {
+  margin: 0;
+  font-size: clamp(2.4rem, 3.2vw, 3.8rem);
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 1.12rem;
+  color: rgba(9, 14, 30, 0.72);
+  line-height: 1.7;
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem 1.4rem;
+  font-size: 0.95rem;
+  color: rgba(9, 14, 30, 0.64);
+}
+
+.badge {
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.logos {
+  display: flex;
+  gap: 1.1rem;
+}
+
+.logo-mark {
+  padding: 0.85rem 1.5rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(12, 16, 32, 0.05);
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.6);
+  transition: transform 320ms ease, box-shadow 320ms ease;
+}
+
+.logo-mark:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 30px rgba(10, 132, 255, 0.18);
+}
+
+.logo-mark.secondary {
+  opacity: 0.72;
+}
+
+.intro {
+  max-width: 32ch;
+  font-size: 1rem;
+  color: rgba(9, 14, 30, 0.66);
+}
+
+.hero-map {
+  width: min(360px, 100%);
+  justify-items: center;
+  gap: 1.2rem;
+}
+
+.hero-map svg {
+  width: 100%;
+  height: auto;
+  border-radius: 36px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5), 0 30px 80px rgba(10, 132, 255, 0.24);
+}
+
+.data-chip {
+  position: absolute;
+  bottom: 5%;
+  right: -5%;
+  padding: 0.9rem 1.3rem;
+  border-radius: 16px;
+  background: rgba(10, 132, 255, 0.16);
+  color: var(--accent);
+  font-weight: 600;
+  display: flex;
+  gap: 0.6rem;
+  align-items: baseline;
+  animation: float 3.2s ease-in-out infinite;
+}
+
+.data-chip.secondary {
+  bottom: auto;
+  top: 6%;
+  right: -2%;
+  background: rgba(120, 188, 255, 0.22);
+  animation-delay: 1.4s;
+}
+
+.data-chip span {
+  font-size: 1.3rem;
+}
+
+.pulse {
+  fill: rgba(255, 255, 255, 0.95);
+  animation: pulse 2.6s ease-in-out infinite;
+}
+
+.pulse.delayed {
+  animation-delay: 1.2s;
+}
+
+.video-frame {
+  width: min(420px, 100%);
+  aspect-ratio: 16 / 10;
+  border-radius: 32px;
+  background: radial-gradient(circle at top left, rgba(10, 132, 255, 0.4), rgba(10, 132, 255, 0.1)), #081120;
+  overflow: hidden;
+  position: relative;
+  box-shadow: 0 25px 80px rgba(8, 17, 32, 0.46);
+}
+
+.video-overlay {
+  position: absolute;
+  inset: auto 0 0;
+  padding: 1.6rem;
+  color: rgba(255, 255, 255, 0.88);
+  background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.65));
+}
+
+.video-overlay span {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.play-btn {
+  position: absolute;
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.82);
+  border: none;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 15px 40px rgba(10, 132, 255, 0.4);
+  transition: transform 240ms ease, box-shadow 240ms ease;
+}
+
+.play-btn::before {
+  content: "";
+  border-style: solid;
+  border-width: 12px 0 12px 18px;
+  border-color: transparent transparent transparent rgba(10, 132, 255, 0.95);
+  margin-left: 4px;
+}
+
+.play-btn:hover {
+  transform: translate(-50%, -50%) scale(1.06);
+  box-shadow: 0 22px 45px rgba(10, 132, 255, 0.45);
+}
+
+.bullet-list, .notes ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  color: rgba(9, 14, 30, 0.72);
+}
+
+.bullet-list li {
+  padding-left: 1.5rem;
+  position: relative;
+}
+
+.bullet-list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.65rem;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 6px rgba(10, 132, 255, 0.08);
+}
+
+.callout {
+  border-radius: var(--radius-small);
+  background: var(--accent-soft);
+  padding: 1rem 1.2rem;
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.callout strong {
+  font-size: 1rem;
+}
+
+.callout .cta {
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.course-ring {
+  position: relative;
+  width: min(440px, 60vw);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 1px solid rgba(10, 132, 255, 0.24);
+  margin: 0 auto;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle, rgba(10, 132, 255, 0.2) 0, rgba(10, 132, 255, 0.05) 40%, transparent 65%);
+}
+
+.ring-core {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.75);
+  font-weight: 700;
+  box-shadow: 0 18px 40px rgba(10, 132, 255, 0.18);
+}
+
+.ring-item {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 140px;
+  height: 140px;
+  border-radius: 32px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 18px 40px rgba(10, 132, 255, 0.16);
+  transform: rotate(calc(var(--i) * 72deg)) translateY(-210px) rotate(calc(var(--i) * -72deg));
+  transition: transform 320ms ease;
+  padding: 0 0.6rem;
+  text-align: center;
+  font-weight: 600;
+}
+
+.ring-item:hover {
+  transform: rotate(calc(var(--i) * 72deg)) translateY(-210px) rotate(calc(var(--i) * -72deg)) scale(1.05);
+}
+
+.notes {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  color: rgba(9, 14, 30, 0.55);
+  font-size: 0.9rem;
+}
+
+.notes .micro-copy::before {
+  content: "· ";
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.6rem;
+}
+
+.card-grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card {
+  padding: 1.8rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  transition: transform 280ms ease, box-shadow 280ms ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 20px 40px rgba(9, 14, 30, 0.18);
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.card p {
+  margin: 0;
+  color: rgba(9, 14, 30, 0.68);
+}
+
+.icon.halo {
+  width: 64px;
+  height: 64px;
+  border-radius: 24px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.consensus {
+  display: grid;
+  gap: 1.3rem;
+}
+
+.consensus-item {
+  border-radius: 26px;
+  padding: 1.6rem 1.8rem;
+  background: var(--accent-gradient);
+  position: relative;
+  overflow: hidden;
+}
+
+.consensus-item::after {
+  content: "";
+  position: absolute;
+  inset: -40% 40% auto -30%;
+  height: 160%;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.3), transparent);
+  transform: rotate(8deg);
+}
+
+.consensus-item strong {
+  display: block;
+  font-size: 1.35rem;
+  margin-bottom: 0.4rem;
+}
+
+.consensus-item .label {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(9, 14, 30, 0.6);
+}
+
+.next-section {
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 1.8rem;
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  align-self: stretch;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.next-section h4 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--accent);
+}
+
+.next-section p {
+  margin: 0;
+  color: rgba(9, 14, 30, 0.68);
+}
+
+.data-panels {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.data-panels .panel {
+  padding: 1.4rem 1.6rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.05);
+  display: grid;
+  gap: 0.7rem;
+}
+
+.data-panels .panel header {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.data-panels .panel ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+  color: rgba(9, 14, 30, 0.7);
+}
+
+.data-panels .panel ul li::marker {
+  color: var(--accent);
+}
+
+.data-panels .panel.accent {
+  background: var(--accent-soft);
+  color: var(--accent);
+  box-shadow: none;
+}
+
+.flow-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.flow-strip.detailed {
+  gap: 1.2rem;
+}
+
+.flow-item {
+  padding: 1.2rem 1.4rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  text-align: center;
+  font-weight: 600;
+  position: relative;
+  overflow: hidden;
+  animation: reveal 0.9s ease forwards;
+  opacity: 0;
+}
+
+.flow-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.45), transparent 50%);
+  transform: translateX(-100%);
+  animation: shimmer 2.8s ease-in-out infinite;
+}
+
+.flow-item:nth-child(1) { animation-delay: 0.1s; }
+.flow-item:nth-child(2) { animation-delay: 0.35s; }
+.flow-item:nth-child(3) { animation-delay: 0.6s; }
+.flow-item:nth-child(4) { animation-delay: 0.85s; }
+.flow-item:nth-child(5) { animation-delay: 1.1s; }
+
+.triangle-grid {
+  position: relative;
+  width: min(600px, 80vw);
+  margin: 0 auto;
+  aspect-ratio: 1;
+}
+
+.triangle-item {
+  position: absolute;
+  width: 200px;
+  padding: 1.2rem 1.4rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  text-align: center;
+}
+
+.triangle-item span {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.triangle-item.top { top: 2%; left: 50%; transform: translateX(-50%); }
+.triangle-item.left { bottom: 8%; left: 6%; }
+.triangle-item.right { bottom: 8%; right: 6%; }
+
+.triangle-core {
+  position: absolute;
+  inset: 35% 28%;
+  display: grid;
+  place-items: center;
+  border-radius: 32px;
+  background: var(--accent-soft);
+  font-weight: 600;
+  text-align: center;
+  padding: 2rem;
+}
+
+.sheet {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 28px;
+  padding: 1.8rem;
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.05);
+}
+
+.sheet header {
+  font-weight: 600;
+  color: var(--accent);
+  margin-bottom: 1rem;
+}
+
+.sheet table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.sheet th, .sheet td {
+  padding: 0.75rem 0.8rem;
+  border-bottom: 1px solid rgba(12, 18, 40, 0.08);
+  text-align: left;
+}
+
+.sheet td.highlight {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.chart {
+  background: rgba(255, 255, 255, 0.92);
+  padding: 2rem;
+  border-radius: 28px;
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1rem;
+  align-items: end;
+  min-height: 220px;
+}
+
+.chart-line {
+  background: linear-gradient(180deg, rgba(10, 132, 255, 0.2), var(--accent));
+  border-radius: 24px 24px 12px 12px;
+  height: calc(var(--offset) + 120px);
+  display: grid;
+  align-items: end;
+  justify-items: center;
+  color: rgba(255, 255, 255, 0.88);
+  font-weight: 600;
+  padding-bottom: 0.6rem;
+  animation: grow 1.3s ease forwards;
+  opacity: 0;
+}
+
+.chart-line:nth-child(odd) {
+  background: linear-gradient(180deg, rgba(191, 90, 242, 0.2), var(--accent));
+}
+
+.chart-line:nth-child(1) { animation-delay: 0.1s; }
+.chart-line:nth-child(2) { animation-delay: 0.25s; }
+.chart-line:nth-child(3) { animation-delay: 0.4s; }
+.chart-line:nth-child(4) { animation-delay: 0.55s; }
+.chart-line:nth-child(5) { animation-delay: 0.7s; }
+
+.chart-legend {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  color: rgba(9, 14, 30, 0.6);
+  font-size: 0.9rem;
+}
+
+.chart-legend .dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.excel-mock {
+  width: min(420px, 100%);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(48, 209, 88, 0.22), rgba(48, 209, 88, 0.05));
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 25px 60px rgba(48, 209, 88, 0.25);
+}
+
+.excel-mock header {
+  font-weight: 600;
+  color: rgba(9, 14, 30, 0.75);
+}
+
+.excel-mock ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: rgba(9, 14, 30, 0.74);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.stepper {
+  counter-reset: step;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.stepper li {
+  padding-left: 3rem;
+  position: relative;
+  color: rgba(9, 14, 30, 0.72);
+}
+
+.stepper li::before {
+  counter-increment: step;
+  content: counter(step);
+  position: absolute;
+  left: 0;
+  top: 0.35rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--accent);
+  color: white;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+}
+
+.flow-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.flow-card {
+  padding: 1.6rem 1.8rem;
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  text-align: center;
+  font-weight: 600;
+  position: relative;
+  overflow: hidden;
+}
+
+.flow-card::before {
+  content: "";
+  position: absolute;
+  inset: -10% 80% 0 -15%;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.5), transparent);
+  animation: sweep 5s ease-in-out infinite;
+}
+
+.factor-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.05);
+}
+
+.factor-table th,
+.factor-table td {
+  padding: 1rem 1.4rem;
+  border-bottom: 1px solid rgba(12, 18, 40, 0.08);
+  text-align: left;
+}
+
+.factor-table thead tr {
+  background: linear-gradient(135deg, var(--accent-soft), rgba(255, 255, 255, 0.86));
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.factor-table tbody tr.highlight {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.map-panel {
+  width: min(420px, 100%);
+  border-radius: 28px;
+  padding: 2rem;
+  background: linear-gradient(160deg, var(--accent-soft), rgba(76, 201, 240, 0.18));
+  color: white;
+  display: grid;
+  gap: 1.6rem;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.16);
+}
+
+.map-panel header {
+  font-weight: 600;
+}
+
+.map-markers {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.marker {
+  padding: 0.8rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  position: relative;
+  padding-left: 2.5rem;
+}
+
+.marker::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: white;
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.2);
+}
+
+.ring-flow {
+  position: relative;
+  width: min(540px, 80vw);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  border: 1px dashed var(--accent-soft);
+  margin: 0 auto;
+  display: grid;
+  place-items: center;
+}
+
+.ring-node {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 150px;
+  height: 150px;
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  border: 1px solid var(--accent-soft);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 1rem;
+  color: var(--accent);
+}
+
+.ring-node:nth-child(1) { transform: rotate(0deg) translateY(-230px) rotate(0deg); }
+.ring-node:nth-child(2) { transform: rotate(72deg) translateY(-230px) rotate(-72deg); }
+.ring-node:nth-child(3) { transform: rotate(144deg) translateY(-230px) rotate(-144deg); }
+.ring-node:nth-child(4) { transform: rotate(216deg) translateY(-230px) rotate(-216deg); }
+.ring-node:nth-child(5) { transform: rotate(288deg) translateY(-230px) rotate(-288deg); }
+
+.card-grid.three .card h3 {
+  font-size: 1.4rem;
+}
+
+.ladder {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ladder-step {
+  padding: 1.4rem 1.2rem;
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  text-align: center;
+  font-weight: 600;
+  position: relative;
+}
+
+.ladder-step::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -0.5rem;
+  width: 10px;
+  height: 2px;
+  background: var(--accent);
+  transform: translateY(-50%);
+}
+
+.ladder-step:last-child::after {
+  display: none;
+}
+
+.magnifier-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.6rem;
+}
+
+.magnifier {
+  border-radius: 50%;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  background: radial-gradient(circle, rgba(255, 159, 10, 0.22), rgba(255, 204, 0, 0.08));
+  box-shadow: 0 25px 60px rgba(255, 159, 10, 0.25);
+}
+
+.compare {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.compare-card {
+  padding: 2rem;
+  border-radius: 28px;
+  display: grid;
+  gap: 0.6rem;
+  text-align: center;
+  font-weight: 600;
+  color: white;
+}
+
+.compare-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.compare-card.good {
+  background: linear-gradient(135deg, rgba(48, 209, 88, 0.75), rgba(48, 209, 88, 0.45));
+}
+
+.compare-card.bad {
+  background: linear-gradient(135deg, rgba(255, 69, 58, 0.75), rgba(255, 69, 58, 0.45));
+}
+
+.folder-structure {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.folder {
+  padding: 0.9rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  position: relative;
+  padding-left: 3rem;
+}
+
+.folder::before {
+  content: "";
+  position: absolute;
+  left: 1.1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 12px;
+  border-radius: 4px 4px 2px 2px;
+  background: var(--accent);
+  box-shadow: 0 4px 12px rgba(10, 132, 255, 0.24);
+}
+
+.recap {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.recap-item {
+  padding: 1.6rem;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.88);
+  text-align: center;
+  font-weight: 600;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+}
+
+.chat-panel {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.bubble {
+  padding: 1rem 1.3rem;
+  border-radius: 22px;
+  background: rgba(191, 90, 242, 0.18);
+  color: rgba(9, 14, 30, 0.8);
+  position: relative;
+  max-width: 320px;
+  box-shadow: inset 0 0 0 1px rgba(191, 90, 242, 0.22);
+}
+
+.bubble:nth-child(odd) {
+  background: rgba(10, 132, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(10, 132, 255, 0.2);
+}
+
+.resource-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.6rem;
+}
+
+.resource {
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(9, 14, 30, 0.06);
+  padding: 1.6rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.resource h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--accent);
+}
+
+.caption {
+  color: rgba(9, 14, 30, 0.6);
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.micro-copy {
+  margin: 0;
+}
+
+.resource p {
+  margin: 0;
+  color: rgba(9, 14, 30, 0.7);
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+@keyframes pulse {
+  0% { transform: scale(0.9); opacity: 0.6; }
+  50% { transform: scale(1.05); opacity: 1; }
+  100% { transform: scale(0.9); opacity: 0.6; }
+}
+
+@keyframes reveal {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+}
+
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@keyframes grow {
+  from { height: 80px; opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes sweep {
+  0% { transform: translateX(-120%); }
+  70% { transform: translateX(130%); }
+  100% { transform: translateX(130%); }
+}
+
+@media (max-width: 1180px) {
+  .page-inner.split {
+    grid-template-columns: 1fr;
+  }
+
+  .course-ring {
+    width: min(420px, 80vw);
+  }
+
+  .ring-item {
+    transform: rotate(calc(var(--i) * 72deg)) translateY(-180px) rotate(calc(var(--i) * -72deg));
+  }
+
+}
+
+@media (max-width: 900px) {
+  .card-grid.three,
+  .ladder,
+  .magnifier-grid,
+  .recap,
+  .resource-list,
+  .flow-strip,
+  .compare {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .triangle-grid {
+    aspect-ratio: auto;
+    display: grid;
+    gap: 1rem;
+    position: static;
+  }
+
+  .triangle-item,
+  .triangle-core {
+    position: static;
+    transform: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .scroll-wrapper {
+    scroll-snap-type: none;
+  }
+
+  .page::before {
+    inset: 2%;
+  }
+
+  .page-inner {
+    padding: 2rem;
+  }
+
+  .card-grid.three,
+  .ladder,
+  .magnifier-grid,
+  .recap,
+  .resource-list,
+  .flow-strip,
+  .compare {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Build a 28-screen Apple-inspired training microsite sized for an iPad Pro viewport with scroll snapping and section anchors.
- Implement module-specific layouts for cover, core technology,保障,共鸣, and appendix sections including interactive callouts and next-session prompts.
- Add bespoke visuals and micro-animations for flow diagrams, charts, maps, and call-to-action elements aligned with Sichuan mineral pricing content.

## Testing
- Not run (static HTML/CSS site).


------
https://chatgpt.com/codex/tasks/task_e_68d35f32b82c832cb7b891bff2b8f9bd